### PR TITLE
Add OpenAPI generate script

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,13 @@ bun run build
 
 This generates `dist/index.js`, `dist/index.mjs` and the type declarations in `dist/index.d.ts`.
 IDEs will automatically pick up these types for improved editor support.
+
+## Generating models
+
+Generate TypeScript models from the OpenAPI schema:
+
+```bash
+bun run generate
+```
+
+This will update `src/models.ts` with the latest types.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "lint": "eslint --fix --config .qlty/configs/eslint.config.mjs .",
         "docs": "typedoc --options typedoc.json",
         "typecheck": "tsc --noEmit",
-        "build": "tsup"
+        "build": "tsup",
+        "generate": "openapi-typescript openapi.yml -o src/models.ts"
     },
     "devDependencies": {
         "@eslint/markdown": "^6.5.0",


### PR DESCRIPTION
## Summary
- add `generate` script to package.json
- document generating models from OpenAPI in README

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_b_684d73f0cc5c8329bc0acb67a01bd8cb