### PR TITLE
Fix cosign key handling in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,11 @@ jobs:
               uses: sigstore/cosign-installer@v3
 
             - name: Sign tarball
-              run:
-                  cosign sign-blob --yes --key "$COSIGN_PRIVATE_KEY" --output-signature "${{
-                  steps.pack.outputs.FILE }}.sig" "${{ steps.pack.outputs.FILE }}"
+              run: |
+                  echo "$COSIGN_PRIVATE_KEY" > cosign.key
+                  cosign sign-blob --yes --key cosign.key \
+                      --output-signature "${{ steps.pack.outputs.FILE }}.sig" \
+                      "${{ steps.pack.outputs.FILE }}"
               env:
                   COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
                   COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,12 @@ jobs:
 
             - name: Sign tarball
               run: |
-                  echo "$COSIGN_PRIVATE_KEY" > cosign.key
-                  cosign sign-blob --yes --key cosign.key \
+                  TEMP_KEY_FILE=$(mktemp)
+                  echo "$COSIGN_PRIVATE_KEY" > "$TEMP_KEY_FILE"
+                  cosign sign-blob --yes --key "$TEMP_KEY_FILE" \
                       --output-signature "${{ steps.pack.outputs.FILE }}.sig" \
                       "${{ steps.pack.outputs.FILE }}"
+                  rm -f "$TEMP_KEY_FILE"
               env:
                   COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
                   COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ git tag -s "v$VERSION" -m "v$VERSION"
 git push origin "v$VERSION"
 ```
 
-Ensure `NPM_TOKEN` and `COSIGN_PRIVATE_KEY` secrets are configured.
+Ensure `NPM_TOKEN` is configured and set the `COSIGN_PRIVATE_KEY` secret to the contents of your
+cosign private key. The release workflow writes this secret to a temporary file before signing the
+tarball.
 
 ## Downloading Release Artifacts
 


### PR DESCRIPTION
## Summary
- ensure cosign secret content is written to file before signing
- document how to configure COSIGN_PRIVATE_KEY

## Testing
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_b_686a6e59b1ac83299f534d542b06f0cf