### PR TITLE
Fix docs generation failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,6 @@ dist
 .pnp.*
 
 dist/
-docs/
+docs/api/
 
 .env.test

--- a/docs/starters.md
+++ b/docs/starters.md
@@ -1,0 +1,12 @@
+# Starter Helpers
+
+Pulse includes convenient helper functions for common analysis tasks. These helpers wrap the core client APIs with sensible defaults so you can get started quickly.
+
+```ts
+import { sentimentAnalysis, themeAllocation, clusterAnalysis } from '@rwai/pulse'
+const sentiments = await sentimentAnalysis(['text1', 'text2'], client)
+const allocation = await themeAllocation(['text1', 'text2'], client, ['theme1', 'theme2'])
+const clusters = await clusterAnalysis(['text1', 'text2'], client)
+```
+
+Each helper accepts the texts to analyze and the client instance. The themeAllocation helper can optionally take a list of themes; when omitted it will generate themes automatically.


### PR DESCRIPTION
## Summary
- add `docs/starters.md` referenced by the README and typedoc config
- ignore generated `docs/api` folder rather than the entire `docs` directory

## Testing
- `bun run docs`
- `bun run lint`
- `bun run fmt`
- `bun run test`
- `bun run typecheck`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_b_686a7393bdd483298bde93faf602a782