### PR TITLE
Fix docs generation by adding missing guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,6 @@ dist
 .pnp.*
 
 dist/
-docs/
+docs/api/
 
 .env.test

--- a/docs/starters.md
+++ b/docs/starters.md
@@ -1,0 +1,19 @@
+# Starter Helpers
+
+The starter helpers provide convenient wrappers around the common workflows offered by this package.
+They handle the creation of an `Analyzer` instance and accept either lists of strings or file paths
+(`.txt`, `.csv`, `.tsv`, `.xls`, `.xlsx`). Each helper returns the same result objects as the full
+analysis layer so you can immediately work with the structured output.
+
+The helpers mirror the functions exported from `@rwai/pulse`:
+
+```ts
+import { sentimentAnalysis, themeAllocation, clusterAnalysis } from '@rwai/pulse'
+
+const sentiments = await sentimentAnalysis(['text1', 'text2'])
+const allocation = await themeAllocation(['text1', 'text2'], ['theme1', 'theme2'])
+const clusters = await clusterAnalysis(['text1', 'text2'])
+```
+
+These wrappers are a quick way to get started without constructing a full workflow. They are also
+useful for scripting and exploratory analysis where you want sensible defaults.


### PR DESCRIPTION
## Summary
- ignore generated `docs/api`
- add the missing `Starter Helpers` guide required by typedoc

## Testing
- `bun run test`
- `bun run build`
- `bun run typecheck`
- `bun run docs`


------
https://chatgpt.com/codex/tasks/task_b_686a7393bdd483298bde93faf602a782