### PR TITLE
Fix npm auth and package contents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
             - name: Publish to npm
               run: bun publish --access public
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Create GitHub release
               uses: softprops/action-gh-release@v1

--- a/README.md
+++ b/README.md
@@ -151,9 +151,10 @@ git tag -s "v$VERSION" -m "v$VERSION"
 git push origin "v$VERSION"
 ```
 
-Ensure `NPM_TOKEN` is configured and set the `COSIGN_PRIVATE_KEY` secret to the contents of your
-cosign private key. The release workflow writes this secret to a temporary file before signing the
-tarball.
+Ensure an `NPM_TOKEN` secret is configured. The release workflow exposes this as `NPM_CONFIG_TOKEN`
+so `bun publish` can authenticate with the npm registry. Also set the `COSIGN_PRIVATE_KEY` secret to
+the contents of your cosign private key. The workflow writes this secret to a temporary file before
+signing the tarball.
 
 ## Downloading Release Artifacts
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
     "version": "0.1.0",
     "module": "dist/index.mjs",
     "type": "module",
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE"
+    ],
     "scripts": {
         "clean": "rimraf dist",
         "test": "vitest --run",


### PR DESCRIPTION
## Summary
- fix npm publish step to use `NPM_CONFIG_TOKEN`
- restrict published files with a `files` array
- clarify release docs about `NPM_CONFIG_TOKEN`

## Testing
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test`
- `bun run test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_b_686a7536c68c8329af2c25093a25491b