### PR TITLE
Add manual version bump workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,34 @@
+name: Bump and Tag
+
+on:
+    workflow_dispatch:
+        inputs:
+            level:
+                description: 'Version bump type'
+                required: true
+                type: choice
+                default: patch
+                options:
+                    - patch
+                    - minor
+                    - major
+
+permissions:
+    contents: write
+
+jobs:
+    bump:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Configure Git
+              run: |
+                  git config user.name "${{ github.actor }}"
+                  git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+            - name: Bump package version
+              run: npm version ${{ github.event.inputs.level }} -m "v%s"
+
+            - name: Push changes and tag
+              run: git push origin HEAD --follow-tags

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,6 +19,9 @@ permissions:
 jobs:
     bump:
         runs-on: ubuntu-latest
+        concurrency:
+            group: 'bump-tag-${{ github.ref }}'
+            cancel-in-progress: true
         steps:
             - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- add `Bump and Tag` workflow for releasing new versions

## Testing
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_b_686a8241f1fc83299103dc22822a2b2b