### PR TITLE
Add debug header option to core client

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ const auth = new ClientCredentialsAuth(
 const client = new CoreClient({
     baseUrl: 'https://api.rwai.com/pulse',
     auth,
+    // Include this flag to enable request debugging
+    debug: true,
 })
 ```
 

--- a/src/core/clients/CoreClient.ts
+++ b/src/core/clients/CoreClient.ts
@@ -22,6 +22,8 @@ import { generateThemes, type GenerateThemeOptions } from './generateThemes'
 export class CoreClient {
     private readonly _baseUrl: string
     private readonly _auth: Auth.Auth
+    /** When true, include the `x-pulse-debug` header on requests. */
+    private readonly _debug: boolean
 
     /**
      * Construct a new CoreClient.
@@ -34,6 +36,7 @@ export class CoreClient {
             process.env.PULSE_BASE_URL ??
             'https://core.researchwiseai.com/pulse/v1'
         this._auth = options.auth ?? new Auth.AutoAuth()
+        this._debug = options.debug ?? false
     }
 
     /** The normalized base URL used for API requests. */
@@ -44,6 +47,11 @@ export class CoreClient {
     /** The authenticator instance used to sign requests. */
     get auth(): Auth.Auth {
         return this._auth
+    }
+
+    /** Whether debug mode is enabled. */
+    get debug(): boolean {
+        return this._debug
     }
 
     /**

--- a/src/core/clients/CoreClientOptions.ts
+++ b/src/core/clients/CoreClientOptions.ts
@@ -5,10 +5,13 @@ import type { Auth } from '../../auth'
  *
  * @property baseUrl - Base URL of the Pulse API (no trailing slash).
  * @property auth - Auth strategy instance for request authentication.
+ * @property debug - When true, include the `x-pulse-debug` header on all requests.
  */
 export interface CoreClientOptions {
     /** Base URL of the Pulse API (no trailing slash). */
     baseUrl: string
     /** Authenticator instance to sign API requests. */
     auth: Auth.Auth
+    /** When true, include the `x-pulse-debug` header on all requests. */
+    debug?: boolean
 }

--- a/src/core/clients/__tests__/createEmbeddings.test.ts
+++ b/src/core/clients/__tests__/createEmbeddings.test.ts
@@ -70,6 +70,18 @@ describe('createEmbeddings', () => {
         expect(res).toEqual(responseBody)
     })
 
+    it('sends x-pulse-debug header when client.debug is true', async () => {
+        ;(fetchWithRetry as Mock).mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ requestId: 'r', embeddings: [] }),
+        })
+        const clientWithDebug = { ...client, debug: true } as unknown as CoreClient
+        await createEmbeddings(clientWithDebug, ['a'])
+        const req = (fetchWithRetry as Mock).mock.calls[0][0] as Request
+        expect(req.headers.get('x-pulse-debug')).toBe('true')
+    })
+
     it('returns awaited job result on 202 when awaitJobResult is not false', async () => {
         const jobId = 'job-123'
         ;(fetchWithRetry as Mock)

--- a/src/core/clients/requestFeature.ts
+++ b/src/core/clients/requestFeature.ts
@@ -42,7 +42,10 @@ export async function requestFeature<
 
     const init: FetchOptions = {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+            'Content-Type': 'application/json',
+            ...(client.debug ? { 'x-pulse-debug': 'true' } : {}),
+        },
         body: JSON.stringify(payload),
     }
 
@@ -61,6 +64,7 @@ export async function requestFeature<
             jobId,
             baseUrl: client.baseUrl,
             auth: client.auth,
+            debug: client.debug,
             after,
         })
         // If awaitJobResult is explicitly false


### PR DESCRIPTION
## Summary
- allow `CoreClient` to send a `x-pulse-debug` header
- support debug header in job polling
- document the new option
- test that the header is forwarded when debug mode is on

## Testing
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run docs`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_b_6876360c1c2c8329aeb8534e9a5ee1fe