### PR TITLE
Add internal debug logging

### DIFF
--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -1,0 +1,5 @@
+export function debugLog(debug: boolean, message: string, ...args: unknown[]): void {
+    if (debug) {
+        console.debug(message, ...args)
+    }
+}


### PR DESCRIPTION
## Summary
- add lightweight debug logger
- log job polling progress and outcomes
- log feature request and response details

## Testing
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_b_6878cd2328f48329992001907c88b375