### PR TITLE
Scrub tokens in recordings

### DIFF
--- a/test/recordings/allocates-themes-explicitly_1770653602/recording.har
+++ b/test/recordings/allocates-themes-explicitly_1770653602/recording.har
@@ -74,7 +74,7 @@
                         }
                     },
                     "response": {
-                        "body": "{\"access_token\":\"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImwxRThteER3TnJoQ2l4TzZfYUhQRCJ9.eyJpc3MiOiJodHRwczovL3dpc2UtZGV2LmV1LmF1dGgwLmNvbS8iLCJzdWIiOiJhaUl1ODFDVWRrVlRlRDBhUzRHUHpUWDhuMlE1RURIU0BjbGllbnRzIiwiYXVkIjoiaHR0cHM6Ly9kZXYuY29yZS5yZXNlYXJjaHdpc2VhaS5jb20vcHVsc2UvdjEiLCJpYXQiOjE3NTAwMjA2MTIsImV4cCI6MTc1MDEwNzAxMiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIiwiYXpwIjoiYWlJdTgxQ1Vka1ZUZUQwYVM0R1B6VFg4bjJRNUVESFMifQ.RjoI3SIeaVO-uTwqBtBLYeFFgXBfJht1Z0lFzlIyDahOXCKchP4vxmyibg3M8AmCxNE6F6lcwoGHLSHznthY6jIQqlfDj26Dsq1OM5E_DIHM1gpWOpcdnWVk9eJXcN_vdAcFnhBXSGTQNAinzIhPaOfmCfoHUiFES1b_e33Mgzmtoh-Hw_eeZMbjmp-lStj2ZxMWHOhz8HDsEKH0VjTLrhZg397j8-kS3CzpEgdo1YNTpwAYAA3pRxMTr7F_h5ivG0THcvWAqu5oel7fwDXgavuXxUmZHeRvNL9DsDZJG3Nvue-CKHXlPcJ5EuTSo9n98ECkenqkJOuVMsBzLCBIGA\",\"expires_in\":86400,\"token_type\":\"Bearer\"}",
+                        "body": "{\"access_token\":\"<redacted>\",\"expires_in\":86400,\"token_type\":\"Bearer\"}",
                         "headers": {
                             "alt-svc": "h3=\":443\"; ma=86400",
                             "cache-control": "no-store",

--- a/test/recordings/allocates-themes-implicitly_3623387733/recording.har
+++ b/test/recordings/allocates-themes-implicitly_3623387733/recording.har
@@ -74,7 +74,7 @@
                         }
                     },
                     "response": {
-                        "body": "{\"access_token\":\"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImwxRThteER3TnJoQ2l4TzZfYUhQRCJ9.eyJpc3MiOiJodHRwczovL3dpc2UtZGV2LmV1LmF1dGgwLmNvbS8iLCJzdWIiOiJhaUl1ODFDVWRrVlRlRDBhUzRHUHpUWDhuMlE1RURIU0BjbGllbnRzIiwiYXVkIjoiaHR0cHM6Ly9kZXYuY29yZS5yZXNlYXJjaHdpc2VhaS5jb20vcHVsc2UvdjEiLCJpYXQiOjE3NTAwMjA2MDgsImV4cCI6MTc1MDEwNzAwOCwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIiwiYXpwIjoiYWlJdTgxQ1Vka1ZUZUQwYVM0R1B6VFg4bjJRNUVESFMifQ.aKJrPyQIE32900XaDUB1ziuA_0ZKcGzIKz0bUr8mzRsqDN5kOfZppc9FhRADhkfQ4cxWMuDcYShXfPsjsMu_vbOjWQaZUBFa9b55WHPqe9u6iYKF694LLCXcnRxH1SU9gn-awwcK2-J7Vlw2imD_HvjkuS2tM2O-QDSNwnFzZ3Yn0-iHzLSlDaRW7gJ3Njahye-GI3g42TA7oi_P3TO1XhoIQgdLLkHE5oQpmKw292JKcJ9GcfU5sihAxmctjHjs1lsCLr-gYUzAlTttZu-FrXnK59yNoxRRCSA0V6CCVVGd-u1W1x8NoZvVntsiW1VHUDL2T0oz9lkK8fWoXfKZwA\",\"expires_in\":86400,\"token_type\":\"Bearer\"}",
+                        "body": "{\"access_token\":\"<redacted>\",\"expires_in\":86400,\"token_type\":\"Bearer\"}",
                         "headers": {
                             "alt-svc": "h3=\":443\"; ma=86400",
                             "cache-control": "no-store",

--- a/test/recordings/createEmbeddings-returns-data_277788528/recording.har
+++ b/test/recordings/createEmbeddings-returns-data_277788528/recording.har
@@ -74,7 +74,7 @@
                         }
                     },
                     "response": {
-                        "body": "{\"access_token\":\"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImwxRThteER3TnJoQ2l4TzZfYUhQRCJ9.eyJpc3MiOiJodHRwczovL3dpc2UtZGV2LmV1LmF1dGgwLmNvbS8iLCJzdWIiOiJhaUl1ODFDVWRrVlRlRDBhUzRHUHpUWDhuMlE1RURIU0BjbGllbnRzIiwiYXVkIjoiaHR0cHM6Ly9kZXYuY29yZS5yZXNlYXJjaHdpc2VhaS5jb20vcHVsc2UvdjEiLCJpYXQiOjE3NTAwMjA0MjksImV4cCI6MTc1MDEwNjgyOSwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIiwiYXpwIjoiYWlJdTgxQ1Vka1ZUZUQwYVM0R1B6VFg4bjJRNUVESFMifQ.OpSNThJxWD96jenvTiVO1N3k8FzROhOb8RfyLDeeVTtNPbvNePXo7KY3PjMU2YJmjxQzwQqMjnZK8A_dYtqczrjifrwrvEZXX4FoYAFCI5QAx8WBAH-V2sqBfrH6jN1adJ5SmUiSshdw5PkzSdiLMZlNY-cjNYBoRtsqyqEmFxCopSfb2II3_G9zAy8NTrt7RdFlPdgE8MDV0A-Y7E2PtlXKpNRyEaoDJ4bZby1HiLcsIcOcI-3lJHQw3hL4yfkpH6raUbNLaP6qVF52Nkt8NUEGsajkDx4CSwnHc8xYKeEUbpLZyEc-7xzYIFz8HuAboGvlLM3s1K6nMm9rvd4Uig\",\"expires_in\":86400,\"token_type\":\"Bearer\"}",
+                        "body": "{\"access_token\":\"<redacted>\",\"expires_in\":86400,\"token_type\":\"Bearer\"}",
                         "headers": {
                             "alt-svc": "h3=\":443\"; ma=86400",
                             "cache-control": "no-store",

--- a/test/recordings/generates-between-min-and-max-themes_703911906/recording.har
+++ b/test/recordings/generates-between-min-and-max-themes_703911906/recording.har
@@ -74,7 +74,7 @@
                         }
                     },
                     "response": {
-                        "body": "{\"access_token\":\"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImwxRThteER3TnJoQ2l4TzZfYUhQRCJ9.eyJpc3MiOiJodHRwczovL3dpc2UtZGV2LmV1LmF1dGgwLmNvbS8iLCJzdWIiOiJhaUl1ODFDVWRrVlRlRDBhUzRHUHpUWDhuMlE1RURIU0BjbGllbnRzIiwiYXVkIjoiaHR0cHM6Ly9kZXYuY29yZS5yZXNlYXJjaHdpc2VhaS5jb20vcHVsc2UvdjEiLCJpYXQiOjE3NTAwMjA2NTksImV4cCI6MTc1MDEwNzA1OSwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIiwiYXpwIjoiYWlJdTgxQ1Vka1ZUZUQwYVM0R1B6VFg4bjJRNUVESFMifQ.WnbNFRglP2jFYUA_EIlLaZohLBgInUdNxaeY75FHhJsGwL7uuoIdY5K1YEZ1lXAxHkrRD0zcegJahXt-x_2ici7yNPbeL5EX_fKxbAgf3ezeBmLRL3-Ljmzp7aucT4fa-9RdLe2L3d3xqkm4ztgBcKphkEHOXnvtjf9SHtzUtTArfy6d9_iK1j2_lyd3e2P4uDiMNcCqCLTrr3KhgNIFdeBltOxnDq3WVZj9pVHbpRg1mbgVwD5JJ26sSv3yuBQtlp7ZDLAcjCwKlru2qiNYLuG7fM1XZaD2-vS7EeD5eEVw4X1PnA7B8_7p2eWEzy2D45kWKdz_9VuKzjaO8h-XmQ\",\"expires_in\":86400,\"token_type\":\"Bearer\"}",
+                        "body": "{\"access_token\":\"<redacted>\",\"expires_in\":86400,\"token_type\":\"Bearer\"}",
                         "headers": {
                             "alt-svc": "h3=\":443\"; ma=86400",
                             "cache-control": "no-store",

--- a/test/recordings/returns-ClusterResult-instance_4098431066/recording.har
+++ b/test/recordings/returns-ClusterResult-instance_4098431066/recording.har
@@ -74,7 +74,7 @@
                         }
                     },
                     "response": {
-                        "body": "{\"access_token\":\"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImwxRThteER3TnJoQ2l4TzZfYUhQRCJ9.eyJpc3MiOiJodHRwczovL3dpc2UtZGV2LmV1LmF1dGgwLmNvbS8iLCJzdWIiOiJhaUl1ODFDVWRrVlRlRDBhUzRHUHpUWDhuMlE1RURIU0BjbGllbnRzIiwiYXVkIjoiaHR0cHM6Ly9kZXYuY29yZS5yZXNlYXJjaHdpc2VhaS5jb20vcHVsc2UvdjEiLCJpYXQiOjE3NTAwMjA2MTMsImV4cCI6MTc1MDEwNzAxMywiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIiwiYXpwIjoiYWlJdTgxQ1Vka1ZUZUQwYVM0R1B6VFg4bjJRNUVESFMifQ.ErVtHbjU0IbTUL2f5v39foJGI7un9K9utVOR7eBnPuvBdqulI6kNTME2qeKVFwEVPOdXk876l7RhWXK0JYppdky696ZktT4n6V6CTAC-8ZvvrKXHTZYsE5wjhcLQscJSDVZiKeMMk2KugB_75OCgA7AQ4s8KuP2BeGTvXaPlOSWd8RIquLNGsY4eUrgSgJpc-N4xsavi3Pp9NlIWgfpZjbzelBiDN40MLLSj1n_afAbm1J8GvVpQDgsV2KnFy96syuyf2DuHH6wt107-a4sQcjT3mbU2P_HGHFT-BuPW7eG9Fxq9XqTg6tmXMFAmLXR0g0SiPg6LQA2rSAp_g6F50A\",\"expires_in\":86400,\"token_type\":\"Bearer\"}",
+                        "body": "{\"access_token\":\"<redacted>\",\"expires_in\":86400,\"token_type\":\"Bearer\"}",
                         "headers": {
                             "alt-svc": "h3=\":443\"; ma=86400",
                             "cache-control": "no-store",


### PR DESCRIPTION
## Summary
- sanitize access tokens in test recordings
- recursively scrub tokens in Polly `beforePersist` handler

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_b_6879354b8dfc8329a2c483233d69ab7b