### PR TITLE
Upgrade Zod to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ TypeScript client for the RWAI Pulse API.
 - TypeScript 5.0 or higher
 - Bun 1.0 or higher
 - Qlty CLI
+- Zod 4 or higher (tree-shakeable via `zod/mini`)
 
 ## Installation
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "@rwai/pulse",
       "dependencies": {
-        "zod": "^3.25.64",
+        "zod": "^4",
       },
       "devDependencies": {
         "@dotenvx/dotenvx": "^1.44.2",
@@ -1079,7 +1079,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.25.64", "", {}, "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g=="],
+    "zod": ["zod@4.0.5", "", {}, "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
         "./package.json": "./package.json"
     },
     "dependencies": {
-        "zod": "^3.25.64"
+        "zod": "^4"
     }
 }

--- a/src/dsl.ts
+++ b/src/dsl.ts
@@ -2,7 +2,7 @@
  * DSL builder for composing sequences of Processes.
  */
 import fs from 'fs'
-import { z } from 'zod'
+import { z } from 'zod/mini'
 import { CoreClient } from './core/clients/CoreClient'
 import { Cluster } from './processes/Cluster'
 import { ThemeExtraction } from './processes/ThemeExtraction'
@@ -280,7 +280,9 @@ export class Workflow {
     static fromFile(filePath: string): Workflow {
         const wf = new Workflow()
         const raw = fs.readFileSync(filePath, 'utf-8')
-        const schema = z.object({ pipeline: z.array(z.record(z.unknown())).optional() })
+        const schema = z.object({
+            pipeline: z.optional(z.array(z.record(z.string(), z.unknown()))),
+        })
         const { pipeline } = schema.parse(JSON.parse(raw))
         for (const step of pipeline ?? []) {
             if (

--- a/src/matrix/core/basic.ts
+++ b/src/matrix/core/basic.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod/mini'
 
 // export type SupportedType<T> = T extends [] ? T | Array<T> : Array<T>[];
 
@@ -50,12 +50,10 @@ export type QInt = number & { readonly __QInt: unique symbol }
  *
  * Upon successful validation, the value is narrowed to the `QInt` type.
  */
-export const QInt = z
-    .number()
-    .int()
-    .min(-127)
-    .max(127)
-    .transform(n => n as QInt)
+export const QInt = z.pipe(
+    z.int().check(z.gte(-127)).check(z.lte(127)),
+    z.transform((n: number) => n as QInt),
+)
 
 /**
  * Converts a JavaScript number into a QInt instance.
@@ -84,12 +82,10 @@ export type UQInt = number & { readonly __UQInt: unique symbol }
  *
  * Upon successful validation, the value is narrowed to the `UQInt` type.
  */
-export const UQInt = z
-    .number()
-    .int()
-    .min(0)
-    .max(255)
-    .transform(n => n as UQInt)
+export const UQInt = z.pipe(
+    z.int().check(z.gte(0)).check(z.lte(255)),
+    z.transform((n: number) => n as UQInt),
+)
 /**
  * Converts a JavaScript number into a UQInt instance.
  *


### PR DESCRIPTION
## Summary
- bump zod to v4 and regenerate bun.lock
- import `z` from `zod/mini`
- adapt parsing helpers to new mini API
- note zod version in README

## Testing
- `bun run lint`
- `bun run fmt`
- `bun run typecheck`
- `bun run test`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_b_687c9ee15b4083298a5d4b6c49e63d8c