### PR TITLE
Add version and prune options for theme generation

### DIFF
--- a/src/core/clients/__tests__/generateThemes.test.ts
+++ b/src/core/clients/__tests__/generateThemes.test.ts
@@ -68,6 +68,8 @@ describe('generateThemes', () => {
             fast: true,
             minThemes: 1,
             maxThemes: 5,
+            version: 'v2',
+            prune: 3,
         })
 
         expect(result).toEqual(mockJson)
@@ -78,6 +80,8 @@ describe('generateThemes', () => {
             fast: true,
             minThemes: 1,
             maxThemes: 5,
+            version: 'v2',
+            prune: 3,
         })
         expect(initArg.method).toBe('POST')
         expect(initArg.headers).toEqual({ 'Content-Type': 'application/json' })

--- a/src/core/clients/generateThemes.ts
+++ b/src/core/clients/generateThemes.ts
@@ -17,6 +17,8 @@ export interface GenerateThemeOptions<
     minThemes?: number
     maxThemes?: number
     context?: string
+    version?: string
+    prune?: number
 }
 
 /**
@@ -26,7 +28,7 @@ export interface GenerateThemeOptions<
  * @typeParam AwaitJobResult - If false and fast=false, return a Job handle.
  * @param client - CoreClient instance for API calls.
  * @param inputs - Array of input texts to analyze for themes.
- * @param options - Theme generation options (minThemes, maxThemes, fast, awaitJobResult).
+ * @param options - Theme generation options (minThemes, maxThemes, context, version, prune, fast, awaitJobResult).
  * @returns ThemesResponse or Job<ThemesResponse> based on options.
  */
 export async function generateThemes<
@@ -49,6 +51,8 @@ export async function generateThemes<
             context: options.context,
             maxThemes: options.maxThemes,
             minThemes: options.minThemes,
+            version: options.version,
+            prune: options.prune,
         },
         options,
     )


### PR DESCRIPTION
## Summary
- expose `version` and `prune` in `GenerateThemeOptions`
- include these fields in the request payload
- update tests to verify payload with new parameters

## Testing
- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_b_687c9fff1a1c8329b9516851255714af