### PR TITLE
Add version support for sentiment API

### DIFF
--- a/src/core/clients/analyzeSentiment.ts
+++ b/src/core/clients/analyzeSentiment.ts
@@ -10,10 +10,12 @@ import type { components } from '../../models'
  * @property fast - If true, performs a quicker analysis with potentially reduced accuracy. Defaults to false.
  * @property awaitJobResult - If true, waits for the sentiment analysis job to complete before returning the result. Defaults to false.
  */
-export type AnalyzeSentimentOptions<
+export interface AnalyzeSentimentOptions<
     Fast extends boolean | undefined,
     AwaitJobResult extends boolean | undefined,
-> = UniversalFeatureOptions<Fast, AwaitJobResult>
+> extends UniversalFeatureOptions<Fast, AwaitJobResult> {
+    version?: string
+}
 /**
  * Analyzes the sentiment of the provided inputs using the CoreClient.
  *
@@ -39,5 +41,13 @@ export async function analyzeSentiment<
         ? Job<components['schemas']['SentimentResponse']>
         : components['schemas']['SentimentResponse']
 > {
-    return requestFeature(client, '/sentiment', { inputs }, options)
+    return requestFeature(
+        client,
+        '/sentiment',
+        {
+            inputs,
+            version: options.version,
+        },
+        options,
+    )
 }

--- a/src/core/clients/analyzeSentiment.ts
+++ b/src/core/clients/analyzeSentiment.ts
@@ -46,7 +46,7 @@ export async function analyzeSentiment<
         '/sentiment',
         {
             inputs,
-            version: options.version,
+            ...(options.version !== undefined && { version: options.version }),
         },
         options,
     )


### PR DESCRIPTION
## Summary
- extend `AnalyzeSentimentOptions` to accept an optional `version`
- include `version` in the request payload for `analyzeSentiment`
- test that `version` is sent when provided

## Testing
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_b_687ca22cbdb48329803425bcd79eef49