### PR TITLE
Refactor theme extraction API helpers

### DIFF
--- a/src/processes/ThemeExtraction.ts
+++ b/src/processes/ThemeExtraction.ts
@@ -67,7 +67,12 @@ export class ThemeExtraction<Name extends string = 'themeExtraction'>
         const reps = this.themeRepresentatives(ctx)
         const dictionary: Record<string, string[]> = {}
         reps.forEach((rep, i) => {
-            dictionary[categories[i] as string] = rep.split('\n')
+            const category = categories[i];
+            if (typeof category === 'string') {
+                dictionary[category] = rep.split('\n');
+            } else {
+                console.warn(`Invalid category at index ${i}:`, category);
+            }
         })
         const response = await ctx.client.extractElements(
             {

--- a/src/processes/ThemeExtraction.ts
+++ b/src/processes/ThemeExtraction.ts
@@ -22,7 +22,7 @@ export class ThemeExtraction<Name extends string = 'themeExtraction'>
 
     version?: string
     fast?: boolean
-    threshold: number
+    threshold?: number
 
     /**
      * Create a new ThemeExtraction process instance.

--- a/src/results/index.ts
+++ b/src/results/index.ts
@@ -1,5 +1,3 @@
-import type { components } from '../models'
-
 /**
  * Results of clustering with helper methods.
  */
@@ -23,23 +21,34 @@ export class ClusterResult {
  * Results of theme extraction with helper methods.
  */
 export class ThemeExtractionResult {
+    private data: { columns: string[]; matrix: number[][]; requestId: string }
+
     /**
-     * @param response - The API response containing extraction data.
+     * @param data - Extraction results containing the category matrix.
      * @param texts - Original array of texts processed.
      */
     constructor(
-        private response: components['schemas']['ExtractionsResponse'],
+        data: { columns: string[]; matrix: number[][]; requestId: string },
         private texts: string[],
-    ) {}
+    ) {
+        this.data = data
+    }
 
     /** Category columns returned by the API. */
     get columns(): string[] {
-        return this.response.columns
+        return this.data.columns
     }
 
     /** Matrix of category scores per input text. */
     get matrix(): number[][] {
-        return this.response.matrix
+        return this.data.matrix
+    }
+
+    /**
+     * Request identifier returned by the API.
+     */
+    get requestId(): string {
+        return this.data.requestId
     }
 
     /**


### PR DESCRIPTION
## Summary
- extend `ThemeExtraction` to build dictionary and send threshold
- update `ThemeExtractionResult` signature to store matrix and requestId directly

## Testing
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_b_687f6c31371083299b61743b60909c3a