### PR TITLE
Add extractElements tests

### DIFF
--- a/src/core/clients/__tests__/extractElements.test.ts
+++ b/src/core/clients/__tests__/extractElements.test.ts
@@ -73,7 +73,12 @@ describe('extractElements', () => {
             status: 202,
             json: vi.fn().mockResolvedValue({ jobId: 'job123' }),
         })
-        const fakeJob = {}
+        const fakeJob = {
+            jobId: 'job123',
+            baseUrl: client.baseUrl,
+            auth: client.auth,
+            result: vi.fn(),
+        }
         ;(Job as unknown as Mock).mockImplementation(() => fakeJob)
 
         const result = await extractElements(

--- a/src/core/clients/__tests__/extractElements.test.ts
+++ b/src/core/clients/__tests__/extractElements.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest'
+import { extractElements } from '../extractElements'
+import type { CoreClient } from '../CoreClient'
+import { fetchWithRetry } from '../../../http'
+import { Job } from '../../job'
+import { setupPolly } from '../../../../test/setupPolly'
+import type { components } from '../../../models'
+
+vi.mock('../../../http', () => ({
+    fetchWithRetry: vi.fn(),
+}))
+
+vi.mock('../../job', async importOriginal => {
+    return {
+        ...(await importOriginal<typeof import('../../job')>()),
+        Job: vi.fn(function (
+            this: Record<string, unknown>,
+            options: { jobId: string; baseUrl: string; auth: unknown },
+        ) {
+            this.jobId = options.jobId
+            this.baseUrl = options.baseUrl
+            this.auth = options.auth
+            this.result = vi.fn()
+        }),
+    }
+})
+
+const fetchMock = fetchWithRetry as unknown as Mock
+
+function makeClient(): CoreClient {
+    return {
+        baseUrl: 'http://api.test',
+        auth: {
+            authFlow: vi.fn(() => ({
+                next: async () => ({ value: new Request('http://api.test/extractions') }),
+            })),
+        },
+    } as unknown as CoreClient
+}
+
+describe('extractElements', () => {
+    setupPolly()
+
+    let client: CoreClient
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        client = makeClient()
+    })
+
+    it('returns ExtractionsResponse on 200', async () => {
+        const resp: components['schemas']['ExtractionsResponse'] = {
+            columns: ['A'],
+            matrix: [[1]],
+            requestId: 'req',
+        }
+        fetchMock.mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: vi.fn().mockResolvedValue(resp),
+        })
+
+        const result = await extractElements(client, { texts: ['t'] }, { fast: true })
+
+        expect(result).toEqual(resp)
+        const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string)
+        expect(body.fast).toBe(true)
+    })
+
+    it('returns Job when 202 and awaitJobResult is false', async () => {
+        fetchMock.mockResolvedValue({
+            ok: true,
+            status: 202,
+            json: vi.fn().mockResolvedValue({ jobId: 'job123' }),
+        })
+        const fakeJob = {}
+        ;(Job as unknown as Mock).mockImplementation(() => fakeJob)
+
+        const result = await extractElements(
+            client,
+            { texts: ['a'] },
+            { fast: false, awaitJobResult: false },
+        )
+
+        expect(result).toBe(fakeJob)
+        expect(Job).toHaveBeenCalledWith({
+            after: expect.any(Function),
+            jobId: 'job123',
+            baseUrl: client.baseUrl,
+            auth: client.auth,
+        })
+    })
+})

--- a/src/core/clients/extractElements.ts
+++ b/src/core/clients/extractElements.ts
@@ -48,13 +48,13 @@ export type ExtractElementsOptions<
  * @param client - CoreClient instance for API calls.
  * @param inputs - Inputs including texts and theme labels.
  * @param options - Extraction options (fast, awaitJobResult).
- * @returns ExtractionsResponse or JobResponse based on options.
+ * @returns ExtractionsResponse or Job handle based on options.
  */
 export async function extractElements<
     Fast extends boolean | undefined,
     AwaitJobResult extends boolean | undefined,
     Result = AwaitJobResult extends false
-        ? components['schemas']['JobResponse']
+        ? Job<components['schemas']['ExtractionsResponse']>
         : components['schemas']['ExtractionsResponse'],
 >(
     client: CoreClient,
@@ -72,17 +72,10 @@ export async function extractElements<
         version: inputs.version,
     }
 
-    const res = await requestFeature<
+    return requestFeature<
         Omit<ExtractionsRequest, 'fast'>,
         ExtractionsResponse,
         Fast,
         AwaitJobResult
-    >(client, '/extractions', body, { awaitJobResult, fast })
-
-    if (awaitJobResult === false) {
-        const job = res as unknown as Job<ExtractionsResponse>
-        return { job_id: job.jobId } as Result
-    }
-
-    return res as Result
+    >(client, '/extractions', body, { awaitJobResult, fast }) as Promise<Result>
 }

--- a/test/results.test.ts
+++ b/test/results.test.ts
@@ -109,4 +109,19 @@ describe('ThemeExtractionResult', () => {
             { text: 'B1', category: 'B', score: 1 },
         ])
     })
+
+    it('exposes columns and matrix from the response', () => {
+        const resp: components['schemas']['ExtractionsResponse'] = {
+            requestId: 'r',
+            columns: ['X', 'Y'],
+            matrix: [
+                [0.1, 0.9],
+                [0.4, 0.6],
+            ],
+        }
+        const r = new ThemeExtractionResult(resp, ['x', 'y'])
+        expect(r.columns).toEqual(resp.columns)
+        expect(r.matrix).toEqual(resp.matrix)
+        expect(r.requestId).toBe('r')
+    })
 })


### PR DESCRIPTION
## Summary
- cover `extractElements` client helper with unit tests
- ensure `ThemeExtractionResult` exposes columns and matrix getters
- return `Job` instance for async element extraction

## Testing
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_b_6880cbdac9588329b50c1cc82d8b63b3