### PR TITLE
Update docs for summarize starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Pulse provides helpers and a workflow DSL to make analysis easy. For an overview
 functions see the [Starter Helpers guide](docs/starters.md).
 
 ```ts
-import { sentimentAnalysis, themeAllocation, clusterAnalysis } from '@rwai/pulse'
+import { sentimentAnalysis, themeAllocation, clusterAnalysis, summarize } from '@rwai/pulse'
 
 const sentiments = await sentimentAnalysis(['text1', 'text2'])
 const allocation = await themeAllocation(['text1', 'text2'], ['theme1', 'theme2'])
@@ -40,6 +40,7 @@ const allocation = await themeAllocation(['text1', 'text2'], ['theme1', 'theme2'
 // Themes are optional in the themeAllocation function
 const allocationWithoutThemes = await themeAllocation(['text1', 'text2'])
 const clusters = await clusterAnalysis(['text1', 'text2'])
+const summary = await summarize(['text1', 'text2'], 'What is the gist?')
 ```
 
 ### Authentication

--- a/docs/starters.md
+++ b/docs/starters.md
@@ -8,12 +8,33 @@ analysis layer so you can immediately work with the structured output.
 The helpers mirror the functions exported from `@rwai/pulse`:
 
 ```ts
-import { sentimentAnalysis, themeAllocation, clusterAnalysis } from '@rwai/pulse'
+import { sentimentAnalysis, themeAllocation, clusterAnalysis, summarize } from '@rwai/pulse'
 
 const sentiments = await sentimentAnalysis(['text1', 'text2'])
 const allocation = await themeAllocation(['text1', 'text2'], ['theme1', 'theme2'])
 const clusters = await clusterAnalysis(['text1', 'text2'])
+const summary = await summarize(['text1', 'text2'], 'What is the gist?')
 ```
 
 These wrappers are a quick way to get started without constructing a full workflow. They are also
 useful for scripting and exploratory analysis where you want sensible defaults.
+
+## Summarize
+
+The `summarize` helper generates a short answer or overview for a set of texts using a question
+prompt. It accepts the same input formats as the other helpers and returns a `SummariesResponse`
+object:
+
+```ts
+const reviewSummary = await summarize(
+    ['loved it', 'could be better'],
+    'What do customers think overall?',
+)
+console.log(reviewSummary.summary)
+
+// control the length or style of the summary
+await summarize('reviews.csv', 'Key takeaways?', {
+    length: 'short',
+    preset: 'one-pager',
+})
+```

--- a/scripts/coverage-by-feature.mjs
+++ b/scripts/coverage-by-feature.mjs
@@ -1,13 +1,16 @@
 import fs from 'fs'
 
-let lcov;
+let lcov
 try {
-    lcov = fs.readFileSync('coverage/lcov.info', 'utf8');
+    lcov = fs.readFileSync('coverage/lcov.info', 'utf8')
 } catch (err) {
-    console.error("Error: Unable to read 'coverage/lcov.info'. Please ensure the file exists and is accessible.");
-    process.exit(1);
+    console.error(
+        "Error: Unable to read 'coverage/lcov.info'. Please ensure the file exists and is accessible.",
+        err,
+    )
+    process.exit(1)
 }
-const sections = lcov.split('end_of_record');
+const sections = lcov.split('end_of_record')
 const groups = {
     starters: [/src\/starters\.ts$/],
     dsl: [/src\/dsl\.ts$/],


### PR DESCRIPTION
## Summary
- document `summarize` helper in starters guide and README
- extend example code snippets to show summary helper usage
- fix lint issue in coverage-by-feature script

## Testing
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run generate`
- `bun run docs`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_b_68836946638c83298db3abf264d8a87d