### PR TITLE
feat: update extractions contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Update extractions endpoint contract and client to use new inputs and results.
+
 ## [0.1.0] - 2025-06-15
 
 - Initial pre-release of the TypeScript client
@@ -9,4 +13,5 @@ All notable changes to this project will be documented in this file.
 - Includes typed models generated from the OpenAPI schema
 - Bundled using tsup and tested with vitest
 
+[Unreleased]: https://github.com/rwai/pulse-ts/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/rwai/pulse-ts/releases/tag/v0.1.0

--- a/openapi.yml
+++ b/openapi.yml
@@ -412,16 +412,10 @@ paths:
     /extractions:
         post:
             operationId: extractElements
-            summary: Extract elements matching themes from input strings.
+            summary: Extract terms matching a category from input texts.
             description: |
-                Extracts substrings from inputs that match the provided themes.
-                Supports synchronous (fast=true) and asynchronous (fast=false or omitted) modes.
-
-                 - Both modes support up to 200 input strings and up to 50 themes.
-                 - Synchronous mode returns extraction results immediately (HTTP 200).
-                 - Asynchronous mode returns a job_id (HTTP 202) to poll via the /jobs endpoint.
-
-                Returns a matrix where `matrix[i][j]` indicates how strongly input `i` matches category `columns[j]`.
+                Extracts mentions from each input based on a required category and dictionary.
+                Optionally expands the dictionary before matching.
             tags: [extractions]
             requestBody:
                 required: true
@@ -433,8 +427,10 @@ paths:
                             Default:
                                 summary: Basic extractions request
                                 value:
-                                    texts: ['The food was great and the service was slow.']
-                                    categories: ['food', 'service']
+                                    inputs:
+                                        - 'The food was great and the service was slow.'
+                                    category: 'service'
+                                    dictionary: ['service', 'wait time']
             responses:
                 '200':
                     description: Extraction results returned successfully.
@@ -446,16 +442,9 @@ paths:
                                 ExtractionsResponseExample:
                                     summary: Sample extractions response
                                     value:
-                                        columns: ['food', 'service']
-                                        matrix:
-                                            - [1, 1]
-                                        requestId: 'example-request-id'
-                '202':
-                    description: Extraction job accepted for asynchronous processing.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/JobResponse'
+                                        dictionary: ['service', 'wait time']
+                                        results:
+                                            - [['service'], ['service was slow']]
                 '400':
                     description: Bad request - validation error.
                     content:
@@ -466,9 +455,7 @@ paths:
                                 InvalidExtractionsRequest:
                                     summary: Sample validation error response
                                     value:
-                                        message:
-                                            'Validation error: texts must be an array of 1 to 200
-                                            strings and categories must be an array of 1 to 50 strings.'
+                                        message: 'Validation error: invalid extraction request'
 
     /summaries:
         post:
@@ -927,61 +914,44 @@ components:
         ExtractionsRequest:
             type: object
             properties:
-                texts:
+                inputs:
                     type: array
                     minItems: 1
                     maxItems: 200
                     items:
                         type: string
-                categories:
+                category:
+                    type: string
+                dictionary:
                     type: array
-                    minItems: 1
-                    maxItems: 50
                     items:
                         type: string
-                dictionary:
-                    type: object
-                    additionalProperties:
-                        type: array
-                        items:
-                            type: string
+                    description: Required list of canonical terms to match.
                 expand_dictionary:
                     type: boolean
-                use_ner:
-                    type: boolean
-                use_llm:
-                    type: boolean
-                threshold:
+                    default: false
+                expand_dictionary_limit:
                     type: number
-                    minimum: 0
-                    maximum: 1
-                version:
-                    type: string
-                fast:
-                    type: boolean
-                    description:
-                        Flag indicating synchronous (true) or asynchronous (false) processing.
-                        Default false.
-            required: [texts]
+                    description: Optional limit on number of additions when expanding.
+            required: [inputs, category, dictionary]
             additionalProperties: false
 
         ExtractionsResponse:
             type: object
             properties:
-                columns:
+                dictionary:
                     type: array
                     items:
                         type: string
-                matrix:
+                results:
                     type: array
                     items:
                         type: array
                         items:
-                            type: number
-                            format: float
-                requestId:
-                    type: string
-            required: [columns, matrix, requestId]
+                            type: array
+                            items:
+                                type: string
+            required: [dictionary, results]
             additionalProperties: false
 
         SummariesRequest:

--- a/src/core/clients/CoreClient.ts
+++ b/src/core/clients/CoreClient.ts
@@ -7,11 +7,7 @@ import {
 } from './compareSimilarity'
 import type { CoreClientOptions } from './CoreClientOptions'
 import { createEmbeddings, type CreateEmbeddingsOptions } from './createEmbeddings'
-import {
-    extractElements,
-    type ExtractElementsInputs,
-    type ExtractElementsOptions,
-} from './extractElements'
+import { extractElements, type ExtractElementsInputs } from './extractElements'
 import { generateThemes, type GenerateThemeOptions } from './generateThemes'
 import { clusterTexts, type ClusterTextsInputs, type ClusterTextsOptions } from './clusterTexts'
 import { generateSummary, type GenerateSummaryOptions } from './generateSummary'
@@ -123,17 +119,11 @@ export class CoreClient {
     /**
      * Extract specified elements from an array of input texts.
      *
-     * @typeParam Fast - Flag to enable synchronous processing.
-     * @typeParam AwaitJobResult - Flag to await background job result.
-     * @param inputs - Elements extraction inputs including texts and optional categories.
-     * @param opts - Extraction options (fast, awaitJobResult).
-     * @returns ExtractionsResponse or Job handle, based on options.
+     * @param inputs - Elements extraction inputs including texts and category.
+     * @returns ExtractionsResponse.
      */
-    async extractElements<
-        Fast extends boolean | undefined = undefined,
-        AwaitJobResult extends boolean | undefined = undefined,
-    >(inputs: ExtractElementsInputs, opts: ExtractElementsOptions<Fast, AwaitJobResult> = {}) {
-        return extractElements(this, inputs, opts)
+    async extractElements(inputs: ExtractElementsInputs) {
+        return extractElements(this, inputs)
     }
 
     /**

--- a/src/core/clients/__tests__/extractElements.test.ts
+++ b/src/core/clients/__tests__/extractElements.test.ts
@@ -2,28 +2,12 @@ import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest'
 import { extractElements } from '../extractElements'
 import type { CoreClient } from '../CoreClient'
 import { fetchWithRetry } from '../../../http'
-import { Job } from '../../job'
 import { setupPolly } from '../../../../test/setupPolly'
 import type { components } from '../../../models'
 
 vi.mock('../../../http', () => ({
     fetchWithRetry: vi.fn(),
 }))
-
-vi.mock('../../job', async importOriginal => {
-    return {
-        ...(await importOriginal<typeof import('../../job')>()),
-        Job: vi.fn(function (
-            this: Record<string, unknown>,
-            options: { jobId: string; baseUrl: string; auth: unknown },
-        ) {
-            this.jobId = options.jobId
-            this.baseUrl = options.baseUrl
-            this.auth = options.auth
-            this.result = vi.fn()
-        }),
-    }
-})
 
 const fetchMock = fetchWithRetry as unknown as Mock
 
@@ -50,9 +34,8 @@ describe('extractElements', () => {
 
     it('returns ExtractionsResponse on 200', async () => {
         const resp: components['schemas']['ExtractionsResponse'] = {
-            columns: ['A'],
-            matrix: [[1]],
-            requestId: 'req',
+            dictionary: ['service'],
+            results: [[['service'], ['service was slow']]],
         }
         fetchMock.mockResolvedValue({
             ok: true,
@@ -60,39 +43,19 @@ describe('extractElements', () => {
             json: vi.fn().mockResolvedValue(resp),
         })
 
-        const result = await extractElements(client, { texts: ['t'] }, { fast: true })
+        const result = await extractElements(client, {
+            inputs: ['t'],
+            category: 'service',
+            dictionary: ['service'],
+        })
 
         expect(result).toEqual(resp)
         const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string)
-        expect(body.fast).toBe(true)
-    })
-
-    it('returns Job when 202 and awaitJobResult is false', async () => {
-        fetchMock.mockResolvedValue({
-            ok: true,
-            status: 202,
-            json: vi.fn().mockResolvedValue({ jobId: 'job123' }),
-        })
-        const fakeJob = {
-            jobId: 'job123',
-            baseUrl: client.baseUrl,
-            auth: client.auth,
-            result: vi.fn(),
-        }
-        ;(Job as unknown as Mock).mockImplementation(() => fakeJob)
-
-        const result = await extractElements(
-            client,
-            { texts: ['a'] },
-            { fast: false, awaitJobResult: false },
-        )
-
-        expect(result).toBe(fakeJob)
-        expect(Job).toHaveBeenCalledWith({
-            after: expect.any(Function),
-            jobId: 'job123',
-            baseUrl: client.baseUrl,
-            auth: client.auth,
+        expect(body).toEqual({
+            inputs: ['t'],
+            category: 'service',
+            dictionary: ['service'],
+            expand_dictionary: false,
         })
     })
 })

--- a/src/core/clients/extractElements.ts
+++ b/src/core/clients/extractElements.ts
@@ -1,8 +1,6 @@
 import type { components } from '../../models'
 import { requestFeature } from './requestFeature'
 import type { CoreClient } from './CoreClient'
-import type { UniversalFeatureOptions } from './types'
-import type { Job } from '../job'
 
 /**
  * Input parameters for element extraction requests.
@@ -12,70 +10,37 @@ export type ExtractionsResponse = components['schemas']['ExtractionsResponse']
 
 export interface ExtractElementsInputs {
     /** Array of text strings to extract elements from. */
-    texts: string[]
-    /** Optional category labels to guide the extraction. */
-    categories?: string[]
-    /** Optional custom dictionary mapping categories to keywords. */
-    dictionary?: Record<string, string[]>
+    inputs: string[]
+    /** Category label to guide extraction. */
+    category: string
+    /** Canonical terms associated with the category. */
+    dictionary: string[]
     /** Expand the dictionary with related terms. */
     expand_dictionary?: boolean
-    /** Use named-entity recognition for extraction. */
-    use_ner?: boolean
-    /** Use a language model to assist extraction. */
-    use_llm?: boolean
-    /** Confidence threshold for matches. */
-    threshold?: number
-    /** Optional model version to use for extraction. */
-    version?: string
+    /** Optional limit on number of additions when expanding the dictionary. */
+    expand_dictionary_limit?: number
 }
 
 /**
- * Options controlling element extraction requests.
+ * Extract specified elements from texts via the Pulse API.
  *
- * @typeParam Fast - If true, request synchronous processing.
- * @typeParam AwaitJobResult - If false when fast=false, return Job handle.
- */
-export type ExtractElementsOptions<
-    Fast extends boolean | undefined,
-    AwaitJobResult extends boolean | undefined,
-> = UniversalFeatureOptions<Fast, AwaitJobResult>
-
-/**
- * Extract specified elements from texts based on given themes via the Pulse API.
- *
- * @typeParam Fast - If true, request synchronous processing.
- * @typeParam AwaitJobResult - If false and fast=false, return a Job handle.
  * @param client - CoreClient instance for API calls.
- * @param inputs - Inputs including texts and theme labels.
- * @param options - Extraction options (fast, awaitJobResult).
- * @returns ExtractionsResponse or Job handle based on options.
+ * @param inputs - Inputs including texts and category dictionary.
+ * @returns ExtractionsResponse containing matches for each input.
  */
-export async function extractElements<
-    Fast extends boolean | undefined,
-    AwaitJobResult extends boolean | undefined,
-    Result = AwaitJobResult extends false
-        ? Job<components['schemas']['ExtractionsResponse']>
-        : components['schemas']['ExtractionsResponse'],
->(
+export async function extractElements(
     client: CoreClient,
     inputs: ExtractElementsInputs,
-    { awaitJobResult, fast }: ExtractElementsOptions<Fast, AwaitJobResult> = {},
-) {
-    const body: Omit<ExtractionsRequest, 'fast'> = {
-        texts: inputs.texts,
-        categories: inputs.categories,
+): Promise<ExtractionsResponse> {
+    const body: ExtractionsRequest = {
+        inputs: inputs.inputs,
+        category: inputs.category,
         dictionary: inputs.dictionary,
-        expand_dictionary: inputs.expand_dictionary ?? true,
-        use_ner: inputs.use_ner ?? true,
-        use_llm: inputs.use_llm ?? true,
-        threshold: inputs.threshold ?? 0.5,
-        version: inputs.version,
+        expand_dictionary: inputs.expand_dictionary ?? false,
+        ...(inputs.expand_dictionary_limit != null
+            ? { expand_dictionary_limit: inputs.expand_dictionary_limit }
+            : {}),
     }
 
-    return requestFeature<
-        Omit<ExtractionsRequest, 'fast'>,
-        ExtractionsResponse,
-        Fast,
-        AwaitJobResult
-    >(client, '/extractions', body, { awaitJobResult, fast }) as Promise<Result>
+    return requestFeature<ExtractionsRequest, ExtractionsResponse>(client, '/extractions', body, {})
 }

--- a/src/core/clients/index.ts
+++ b/src/core/clients/index.ts
@@ -13,7 +13,7 @@ export type {
     CompareSimilarityCross,
 } from './compareSimilarity'
 export type { CreateEmbeddingsOptions } from './createEmbeddings'
-export type { ExtractElementsInputs, ExtractElementsOptions } from './extractElements'
+export type { ExtractElementsInputs } from './extractElements'
 export type { GenerateThemeOptions } from './generateThemes'
 export type { GenerateSummaryOptions } from './generateSummary'
 export type { UniversalFeatureOptions } from './types'

--- a/src/models.ts
+++ b/src/models.ts
@@ -4,15 +4,15 @@
  */
 
 export interface paths {
-    "/embeddings": {
+    '/embeddings': {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
+        get?: never
+        put?: never
         /**
          * Generate dense vector embeddings for input strings (synchronous or asynchronous).
          * @description Generates dense vector embeddings for input strings in a single batch.
@@ -22,22 +22,22 @@ export interface paths {
          *     • Asynchronous mode accepts up to 2,000 input strings and returns a job_id (HTTP 202) to poll via the /jobs endpoint.
          *
          */
-        post: operations["createEmbeddings"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/similarity": {
+        post: operations['createEmbeddings']
+        delete?: never
+        options?: never
+        head?: never
+        patch?: never
+        trace?: never
+    }
+    '/similarity': {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
+        get?: never
+        put?: never
         /**
          * Compute cosine similarity between strings (self or cross).
          * @description Computes pairwise cosine similarity between input strings.
@@ -47,22 +47,22 @@ export interface paths {
          *     • In asynchronous mode, supports larger inputs (self up to 44,721 items; cross with |set_a|×|set_b| ≤ 2,000,000,000) and returns a job_id (HTTP 202) to poll via the /jobs endpoint.
          *
          */
-        post: operations["compareSimilarity"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/themes": {
+        post: operations['compareSimilarity']
+        delete?: never
+        options?: never
+        head?: never
+        patch?: never
+        trace?: never
+    }
+    '/themes': {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
+        get?: never
+        put?: never
         /**
          * Cluster open-ended text responses into thematic groups.
          * @description Groups input strings into latent themes using LLM-based clustering.
@@ -75,22 +75,22 @@ export interface paths {
          *     Optionally control theme count with `minThemes`, `maxThemes`, and steer focus via `context`.
          *
          */
-        post: operations["generateThemes"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/clustering": {
+        post: operations['generateThemes']
+        delete?: never
+        options?: never
+        head?: never
+        patch?: never
+        trace?: never
+    }
+    '/clustering': {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
+        get?: never
+        put?: never
         /**
          * Cluster texts using vector embeddings.
          * @description Performs server-side clustering of input strings using algorithms that operate on full embeddings.
@@ -100,22 +100,22 @@ export interface paths {
          *      - In asynchronous mode, accepts up to 500 input strings and returns a job_id (HTTP 202) to poll via the /jobs endpoint.
          *
          */
-        post: operations["clusterTexts"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sentiment": {
+        post: operations['clusterTexts']
+        delete?: never
+        options?: never
+        head?: never
+        patch?: never
+        trace?: never
+    }
+    '/sentiment': {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
+        get?: never
+        put?: never
         /**
          * Classify sentiment of each input string.
          * @description Classifies the sentiment of each input string as positive, negative, neutral, or mixed, with confidence scores ∈ [0,1].
@@ -127,50 +127,44 @@ export interface paths {
          *     Optionally supply `version` for reproducible outputs.
          *
          */
-        post: operations["analyzeSentiment"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/extractions": {
+        post: operations['analyzeSentiment']
+        delete?: never
+        options?: never
+        head?: never
+        patch?: never
+        trace?: never
+    }
+    '/extractions': {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
+        get?: never
+        put?: never
         /**
-         * Extract elements matching themes from input strings.
-         * @description Extracts substrings from inputs that match the provided themes.
-         *     Supports synchronous (fast=true) and asynchronous (fast=false or omitted) modes.
-         *
-         *      - Both modes support up to 200 input strings and up to 50 themes.
-         *      - Synchronous mode returns extraction results immediately (HTTP 200).
-         *      - Asynchronous mode returns a job_id (HTTP 202) to poll via the /jobs endpoint.
-         *
-         *     Returns a matrix where `matrix[i][j]` indicates how strongly input `i` matches category `columns[j]`.
+         * Extract terms matching a category from input texts.
+         * @description Extracts mentions from each input based on a required category and dictionary.
+         *     Optionally expands the dictionary before matching.
          *
          */
-        post: operations["extractElements"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/summaries": {
+        post: operations['extractElements']
+        delete?: never
+        options?: never
+        head?: never
+        patch?: never
+        trace?: never
+    }
+    '/summaries': {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
+        get?: never
+        put?: never
         /**
          * Summarize text according to a question.
          * @description Generates a short summary from the provided inputs.
@@ -180,20 +174,20 @@ export interface paths {
          *      - Asynchronous mode accepts up to 5,000 input strings and returns a job_id (HTTP 202) to poll via the /jobs endpoint.
          *
          */
-        post: operations["generateSummary"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/jobs": {
+        post: operations['generateSummary']
+        delete?: never
+        options?: never
+        head?: never
+        patch?: never
+        trace?: never
+    }
+    '/jobs': {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
         /**
          * Retrieve status of an asynchronous job.
          * @description Retrieves the status of a previously submitted long-running job.
@@ -201,472 +195,470 @@ export interface paths {
          *     a `result_url` to download results.
          *
          */
-        get: operations["getJobStatus"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
+        get: operations['getJobStatus']
+        put?: never
+        post?: never
+        delete?: never
+        options?: never
+        head?: never
+        patch?: never
+        trace?: never
+    }
 }
-export type webhooks = Record<string, never>;
+export type webhooks = Record<string, never>
 export interface components {
     schemas: {
         ErrorResponse: {
-            message: string;
+            message: string
             /** @description Optional array of error detail messages */
-            details?: string[];
-        };
+            details?: string[]
+        }
         EmbeddingsRequest: {
             /** @description List of input strings. For synchronous (fast=true) mode, max 200; for asynchronous (fast=false or omitted) mode, max 2000. */
-            inputs: string[];
+            inputs: string[]
             /** @description Flag indicating synchronous (true) or asynchronous (false) processing. Default false. */
-            fast?: boolean;
-        };
+            fast?: boolean
+        }
         EmbeddingDocument: {
-            id?: string;
-            text: string;
-            vector: number[];
-        };
+            id?: string
+            text: string
+            vector: number[]
+        }
         EmbeddingsResponse: {
-            embeddings: components["schemas"]["EmbeddingDocument"][];
-            requestId: string;
-        };
-        UnitAgg: ("sentence" | "newline") | {
-            /** @enum {string} */
-            unit: "sentence" | "newline";
-            /**
-             * @default mean
-             * @enum {string}
-             */
-            agg: "mean" | "max";
-        };
-        Split: components["schemas"]["UnitAgg"] | {
-            set_a?: components["schemas"]["UnitAgg"];
-            set_b?: components["schemas"]["UnitAgg"];
-        };
+            embeddings: components['schemas']['EmbeddingDocument'][]
+            requestId: string
+        }
+        UnitAgg:
+            | ('sentence' | 'newline')
+            | {
+                  /** @enum {string} */
+                  unit: 'sentence' | 'newline'
+                  /**
+                   * @default mean
+                   * @enum {string}
+                   */
+                  agg: 'mean' | 'max'
+              }
+        Split:
+            | components['schemas']['UnitAgg']
+            | {
+                  set_a?: components['schemas']['UnitAgg']
+                  set_b?: components['schemas']['UnitAgg']
+              }
         SimilarityRequest: {
             /** @description Array of strings for self-similarity. For synchronous (fast=true), max 500; for asynchronous (fast=false or omitted), max 44,721. */
-            set?: string[];
+            set?: string[]
             /** @description Array of strings for cross-similarity. For synchronous (fast=true), ensure |set_a|×|set_b| ≤ 20,000; for asynchronous (fast=false or omitted), ensure |set_a|×|set_b| ≤ 2,000,000,000. */
-            set_a?: string[];
+            set_a?: string[]
             /** @description Array of strings for cross-similarity. For synchronous (fast=true), ensure |set_a|×|set_b| ≤ 20,000; for asynchronous (fast=false or omitted), ensure |set_a|×|set_b| ≤ 2,000,000,000. */
-            set_b?: string[];
-            version?: string;
+            set_b?: string[]
+            version?: string
             /** @description Flag indicating synchronous (true) or asynchronous (false) processing. Default false. */
-            fast?: boolean;
+            fast?: boolean
             /** @description For cross-similarity, flatten the matrix into a 1-D array. Ignored for self-similarity. Default false. */
-            flatten?: boolean;
-            split?: components["schemas"]["Split"];
-        } & (unknown | unknown);
+            flatten?: boolean
+            split?: components['schemas']['Split']
+        } & (unknown | unknown)
         SimilarityResponse: {
             /** @enum {string} */
-            scenario: "self" | "cross";
+            scenario: 'self' | 'cross'
             /** @enum {string} */
-            mode: "matrix" | "flattened";
-            n: number;
-            flattened: number[];
-            matrix?: number[][];
-            requestId: string;
-        };
+            mode: 'matrix' | 'flattened'
+            n: number
+            flattened: number[]
+            matrix?: number[][]
+            requestId: string
+        }
         ThemesRequest: {
             /** @description List of input strings. For synchronous (fast=true) mode, max 200; for asynchronous (fast=false or omitted) mode, max 500. */
-            inputs: string[];
-            minThemes?: number;
-            maxThemes?: number;
-            context?: string;
-            version?: string;
-            prune?: number;
+            inputs: string[]
+            minThemes?: number
+            maxThemes?: number
+            context?: string
+            version?: string
+            prune?: number
             /** @description Flag indicating synchronous (true) or asynchronous (false) processing. Default false. */
-            fast?: boolean;
-        };
+            fast?: boolean
+        }
         Theme: {
-            shortLabel: string;
-            label: string;
-            description: string;
+            shortLabel: string
+            label: string
+            description: string
             /** @description Two representative input strings for the theme. */
-            representatives: string[];
-        };
+            representatives: string[]
+        }
         ThemesResponse: {
-            themes: components["schemas"]["Theme"][];
-            requestId: string;
-        };
+            themes: components['schemas']['Theme'][]
+            requestId: string
+        }
         ClusteringRequest: {
             /** @description List of input strings to cluster. For synchronous (fast=true) mode, max 200; asynchronous max 500.
              *      */
-            inputs: string[];
-            k: number;
+            inputs: string[]
+            k: number
             /** @enum {string} */
-            algorithm?: "kmeans" | "skmeans" | "agglomerative" | "hdbscan";
+            algorithm?: 'kmeans' | 'skmeans' | 'agglomerative' | 'hdbscan'
             /** @description Flag indicating synchronous (true) or asynchronous (false) processing. */
-            fast?: boolean;
-        };
+            fast?: boolean
+        }
         Cluster: {
-            clusterId: number;
-            items: string[];
-        };
+            clusterId: number
+            items: string[]
+        }
         ClusteringResponse: {
-            algorithm: string;
-            clusters: components["schemas"]["Cluster"][];
-            requestId: string;
-        };
+            algorithm: string
+            clusters: components['schemas']['Cluster'][]
+            requestId: string
+        }
         SentimentRequest: {
             /** @description List of input strings. For synchronous (fast=true) mode, max 200; for asynchronous (fast=false or omitted) mode, max 10,000. */
-            inputs: string[];
-            version?: string;
+            inputs: string[]
+            version?: string
             /** @description Flag indicating synchronous (true) or asynchronous (false) processing. Default false. */
-            fast?: boolean;
-        };
+            fast?: boolean
+        }
         SentimentResult: {
             /** @enum {string} */
-            sentiment: "positive" | "negative" | "neutral" | "mixed";
-            confidence: number;
-        };
+            sentiment: 'positive' | 'negative' | 'neutral' | 'mixed'
+            confidence: number
+        }
         SentimentResponse: {
-            results: components["schemas"]["SentimentResult"][];
-            requestId: string;
-        };
+            results: components['schemas']['SentimentResult'][]
+            requestId: string
+        }
         ExtractionsRequest: {
-            texts: string[];
-            categories?: string[];
-            dictionary?: {
-                [key: string]: string[];
-            };
-            expand_dictionary?: boolean;
-            use_ner?: boolean;
-            use_llm?: boolean;
-            threshold?: number;
-            version?: string;
-            /** @description Flag indicating synchronous (true) or asynchronous (false) processing. Default false. */
-            fast?: boolean;
-        };
+            inputs: string[]
+            category: string
+            /** @description Required list of canonical terms to match. */
+            dictionary: string[]
+            /** @default false */
+            expand_dictionary: boolean
+            /** @description Optional limit on number of additions when expanding. */
+            expand_dictionary_limit?: number
+        }
         ExtractionsResponse: {
-            columns: string[];
-            matrix: number[][];
-            requestId: string;
-        };
+            dictionary: string[]
+            results: string[][][]
+        }
         SummariesRequest: {
-            inputs: string[];
-            question: string;
+            inputs: string[]
+            question: string
             /** @enum {string} */
-            length?: "bullet-points" | "short" | "medium" | "long";
+            length?: 'bullet-points' | 'short' | 'medium' | 'long'
             /** @enum {string} */
-            preset?: "five-point" | "ten-point" | "one-tweet" | "three-tweets" | "one-para" | "exec" | "two-pager" | "one-pager";
+            preset?:
+                | 'five-point'
+                | 'ten-point'
+                | 'one-tweet'
+                | 'three-tweets'
+                | 'one-para'
+                | 'exec'
+                | 'two-pager'
+                | 'one-pager'
             /** @description Flag indicating synchronous (true) or asynchronous (false) processing. Default false. */
-            fast?: boolean;
-        };
+            fast?: boolean
+        }
         SummariesResponse: {
-            summary: string;
-            requestId: string;
-        };
+            summary: string
+            requestId: string
+        }
         JobResponse: {
-            job_id: string;
-        };
+            job_id: string
+        }
         JobStatusResponse: {
-            job_id?: string;
+            job_id?: string
             /** @enum {string} */
-            status: "pending" | "completed" | "failed";
-            result_url?: string;
-        };
-    };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+            status: 'pending' | 'completed' | 'failed'
+            result_url?: string
+        }
+    }
+    responses: never
+    parameters: never
+    requestBodies: never
+    headers: never
+    pathItems: never
 }
-export type $defs = Record<string, never>;
+export type $defs = Record<string, never>
 export interface operations {
     createEmbeddings: {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
         requestBody: {
             content: {
-                "application/json": components["schemas"]["EmbeddingsRequest"];
-            };
-        };
+                'application/json': components['schemas']['EmbeddingsRequest']
+            }
+        }
         responses: {
             /** @description Embeddings successfully created. */
             200: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["EmbeddingsResponse"];
-                };
-            };
+                    'application/json': components['schemas']['EmbeddingsResponse']
+                }
+            }
             /** @description Bad request - validation error (e.g., >200 strings). */
             400: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
+                    'application/json': components['schemas']['ErrorResponse']
+                }
+            }
+        }
+    }
     compareSimilarity: {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
         requestBody: {
             content: {
-                "application/json": components["schemas"]["SimilarityRequest"];
-            };
-        };
+                'application/json': components['schemas']['SimilarityRequest']
+            }
+        }
         responses: {
             /** @description Similarity values returned successfully. */
             200: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["SimilarityResponse"];
-                };
-            };
+                    'application/json': components['schemas']['SimilarityResponse']
+                }
+            }
             /** @description Bad request - validation error (e.g., invalid input). */
             400: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
+                    'application/json': components['schemas']['ErrorResponse']
+                }
+            }
+        }
+    }
     generateThemes: {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ThemesRequest"];
-            };
-        };
+                'application/json': components['schemas']['ThemesRequest']
+            }
+        }
         responses: {
             /** @description Thematic clustering completed successfully. */
             200: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["ThemesResponse"];
-                };
-            };
+                    'application/json': components['schemas']['ThemesResponse']
+                }
+            }
             /** @description Bad request - validation error (e.g., inputs >200 strings). */
             400: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
+                    'application/json': components['schemas']['ErrorResponse']
+                }
+            }
+        }
+    }
     clusterTexts: {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ClusteringRequest"];
-            };
-        };
+                'application/json': components['schemas']['ClusteringRequest']
+            }
+        }
         responses: {
             /** @description Clustering completed successfully. */
             200: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["ClusteringResponse"];
-                };
-            };
+                    'application/json': components['schemas']['ClusteringResponse']
+                }
+            }
             /** @description Bad request - validation error. */
             400: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
+                    'application/json': components['schemas']['ErrorResponse']
+                }
+            }
+        }
+    }
     analyzeSentiment: {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
         requestBody: {
             content: {
-                "application/json": components["schemas"]["SentimentRequest"];
-            };
-        };
+                'application/json': components['schemas']['SentimentRequest']
+            }
+        }
         responses: {
             /** @description Sentiment analysis results. */
             200: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["SentimentResponse"];
-                };
-            };
+                    'application/json': components['schemas']['SentimentResponse']
+                }
+            }
             /** @description Bad request - validation error. */
             400: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
+                    'application/json': components['schemas']['ErrorResponse']
+                }
+            }
+        }
+    }
     extractElements: {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ExtractionsRequest"];
-            };
-        };
+                'application/json': components['schemas']['ExtractionsRequest']
+            }
+        }
         responses: {
             /** @description Extraction results returned successfully. */
             200: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["ExtractionsResponse"];
-                };
-            };
-            /** @description Extraction job accepted for asynchronous processing. */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JobResponse"];
-                };
-            };
+                    'application/json': components['schemas']['ExtractionsResponse']
+                }
+            }
             /** @description Bad request - validation error. */
             400: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
+                    'application/json': components['schemas']['ErrorResponse']
+                }
+            }
+        }
+    }
     generateSummary: {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
         requestBody: {
             content: {
-                "application/json": components["schemas"]["SummariesRequest"];
-            };
-        };
+                'application/json': components['schemas']['SummariesRequest']
+            }
+        }
         responses: {
             /** @description Summary returned successfully. */
             200: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["SummariesResponse"];
-                };
-            };
+                    'application/json': components['schemas']['SummariesResponse']
+                }
+            }
             /** @description Bad request - validation error. */
             400: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
+                    'application/json': components['schemas']['ErrorResponse']
+                }
+            }
+        }
+    }
     getJobStatus: {
         parameters: {
             query: {
                 /** @description Unique identifier for the job. */
-                jobId: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
+                jobId: string
+            }
+            header?: never
+            path?: never
+            cookie?: never
+        }
+        requestBody?: never
         responses: {
             /** @description Job status returned successfully. */
             200: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["JobStatusResponse"];
-                };
-            };
+                    'application/json': components['schemas']['JobStatusResponse']
+                }
+            }
             /** @description Missing or invalid jobId query parameter. */
             400: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
+                    'application/json': components['schemas']['ErrorResponse']
+                }
+            }
             /** @description Job not found. */
             404: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
+                    'application/json': components['schemas']['ErrorResponse']
+                }
+            }
             /** @description Internal server error. */
             500: {
                 headers: {
-                    [name: string]: unknown;
-                };
+                    [name: string]: unknown
+                }
                 content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
+                    'application/json': components['schemas']['ErrorResponse']
+                }
+            }
+        }
+    }
 }

--- a/src/processes/ThemeExtraction.ts
+++ b/src/processes/ThemeExtraction.ts
@@ -62,28 +62,15 @@ export class ThemeExtraction<Name extends string = 'themeExtraction'>
         const inp = (this as unknown as ProcWithInputs)._inputs?.[0] ?? 'dataset'
         const arr = ctx.datasets[inp]
         const texts: string[] = Array.isArray(arr) ? arr : [arr]
-        const fastFlag = this.fast ?? ctx.fast
         const categories = this.themeLabels(ctx)
         const reps = this.themeRepresentatives(ctx)
-        const dictionary: Record<string, string[]> = {}
-        reps.forEach((rep, i) => {
-            const category = categories[i];
-            if (typeof category === 'string') {
-                dictionary[category] = rep.split('\n');
-            } else {
-                console.warn(`Invalid category at index ${i}:`, category);
-            }
+        const category = categories[0] ?? ''
+        const dictionary = reps[0]?.split('\n') ?? []
+        const response = await ctx.client.extractElements({
+            inputs: texts,
+            category,
+            dictionary,
         })
-        const response = await ctx.client.extractElements(
-            {
-                texts,
-                categories,
-                dictionary,
-                threshold: this.threshold,
-                version: this.version,
-            },
-            { fast: fastFlag },
-        )
         return new ThemeExtractionResult(response, texts)
     }
 }

--- a/src/results/index.ts
+++ b/src/results/index.ts
@@ -21,46 +21,40 @@ export class ClusterResult {
  * Results of theme extraction with helper methods.
  */
 export class ThemeExtractionResult {
-    private data: { columns: string[]; matrix: number[][]; requestId: string }
+    private data: { dictionary: string[]; results: string[][][] }
 
     /**
-     * @param data - Extraction results containing the category matrix.
+     * @param data - Extraction results containing dictionary and matches.
      * @param texts - Original array of texts processed.
      */
     constructor(
-        data: { columns: string[]; matrix: number[][]; requestId: string },
+        data: { dictionary: string[]; results: string[][][] },
         private texts: string[],
     ) {
         this.data = data
     }
 
-    /** Category columns returned by the API. */
-    get columns(): string[] {
-        return this.data.columns
+    /** Canonical dictionary returned by the API. */
+    get dictionary(): string[] {
+        return this.data.dictionary
     }
 
-    /** Matrix of category scores per input text. */
-    get matrix(): number[][] {
-        return this.data.matrix
-    }
-
-    /**
-     * Request identifier returned by the API.
-     */
-    get requestId(): string {
-        return this.data.requestId
+    /** Extraction results per input text. */
+    get results(): string[][][] {
+        return this.data.results
     }
 
     /**
      * Convert extraction results to a flat array of objects.
      *
-     * @returns Array of entries each containing text, category, and score.
+     * @returns Array of entries each containing text, canonical term, and extracted span.
      */
-    toArray(): Array<{ text: string; category: string; score: number }> {
-        const rows: Array<{ text: string; category: string; score: number }> = []
-        this.matrix.forEach((row, i) => {
-            row.forEach((score, j) => {
-                rows.push({ text: this.texts[i], category: this.columns[j], score })
+    toArray(): Array<{ text: string; canonical: string; span: string }> {
+        const rows: Array<{ text: string; canonical: string; span: string }> = []
+        this.results.forEach((res, i) => {
+            const [canonicals = [], spans = []] = res
+            canonicals.forEach((term, idx) => {
+                rows.push({ text: this.texts[i], canonical: term, span: spans[idx] ?? '' })
             })
         })
         return rows

--- a/test/results.test.ts
+++ b/test/results.test.ts
@@ -92,36 +92,30 @@ describe('ClusterResult', () => {
 describe('ThemeExtractionResult', () => {
     it('toArray returns expected extraction rows', () => {
         const response: components['schemas']['ExtractionsResponse'] = {
-            requestId: 'id',
-            columns: ['A', 'B'],
-            matrix: [
-                [1, 0],
-                [0, 1],
+            dictionary: ['service'],
+            results: [
+                [['service'], ['service was slow']],
+                [[], []],
             ],
         }
-        const texts = ['A1 A2', 'B1']
+        const texts = ['The service was slow.', 'All good']
         const r = new ThemeExtractionResult(response, texts)
         const arr = r.toArray()
         expect(arr).toEqual([
-            { text: 'A1 A2', category: 'A', score: 1 },
-            { text: 'A1 A2', category: 'B', score: 0 },
-            { text: 'B1', category: 'A', score: 0 },
-            { text: 'B1', category: 'B', score: 1 },
+            { text: 'The service was slow.', canonical: 'service', span: 'service was slow' },
         ])
     })
 
-    it('exposes columns and matrix from the response', () => {
+    it('exposes dictionary and results from the response', () => {
         const resp: components['schemas']['ExtractionsResponse'] = {
-            requestId: 'r',
-            columns: ['X', 'Y'],
-            matrix: [
-                [0.1, 0.9],
-                [0.4, 0.6],
+            dictionary: ['X', 'Y'],
+            results: [
+                [['X'], ['x found']],
+                [['Y'], ['y found']],
             ],
         }
         const r = new ThemeExtractionResult(resp, ['x', 'y'])
-        expect(r.columns).toEqual(resp.columns)
-        expect(r.matrix).toEqual(resp.matrix)
-        expect(r.requestId).toBe('r')
+        expect(r.dictionary).toEqual(resp.dictionary)
+        expect(r.results).toEqual(resp.results)
     })
 })


### PR DESCRIPTION
## Summary
- update `/extractions` endpoint and schemas for new dictionary/results structure
- adjust `extractElements` client and core wrapper for new request shape
- refactor `ThemeExtractionResult` and tests to use dictionary-based results

## Testing
- `bun run generate`
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test`
- `bun run docs`


------
https://chatgpt.com/codex/tasks/task_b_68a4d4dbb8708329a0905537b8ef2c91